### PR TITLE
fix: correct simple MCP notebook agent import

### DIFF
--- a/notebooks/simple_mcp.ipynb
+++ b/notebooks/simple_mcp.ipynb
@@ -73,7 +73,7 @@
    "outputs": [],
    "source": [
     "from langchain_openai import ChatOpenAI\n",
-    "from langgraph.agents import create_agent\n",
+    "from langchain.agents import create_agent\n",
     "from datetime import date\n",
     "from langgraph.checkpoint.memory import MemorySaver\n",
     "\n",


### PR DESCRIPTION
## Summary
- Fix the `create_agent` import in `notebooks/simple_mcp.ipynb` to use `langchain.agents`.

## Test Plan
- `python3 -m json.tool notebooks/simple_mcp.ipynb >/dev/null`
- `git diff --check`

Closes #7
