### PR TITLE
fix: correct simple MCP agent import

### DIFF
--- a/notebooks/simple_mcp.ipynb
+++ b/notebooks/simple_mcp.ipynb
@@ -73,7 +73,7 @@
    "outputs": [],
    "source": [
     "from langchain_openai import ChatOpenAI\n",
-    "from langgraph.agents import create_agent\n",
+    "from langchain.agents import create_agent\n",
     "from datetime import date\n",
     "from langgraph.checkpoint.memory import MemorySaver\n",
     "\n",


### PR DESCRIPTION
## Problem

Issue #7 reports that `notebooks/simple_mcp.ipynb` imports `create_agent` from `langgraph.agents`, while the notebook should use the LangChain `create_agent` import.

## Solution

Updated the affected import in `notebooks/simple_mcp.ipynb` to:

```python
from langchain.agents import create_agent
```

## Validation

- `python3 -m json.tool notebooks/simple_mcp.ipynb >/dev/null`
- `git diff --check`
- Verified the notebook now has no `from langgraph.agents import create_agent` occurrence.

## Confidence

Score: 85/100
Category: docs/example notebook typo

Related: #7
